### PR TITLE
Added launch_from_std_listener to support prividing own std::net::TcpListener

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,16 @@
 //!         }
 //!     }
 //! }
+//! 
+//! 
+//! fn main() {
+//!     // Example of using a pre-bound listener instead of providing a port.
+//!     let listener = TcpListener::bind(format!("0.0.0.0:8080")).unwrap();
+//!     let websocket_event_hub = simple_websockets::launch_from_listener(listener).expect("failed to listen on port 8080");
+//! 
+//!     ...
+//! }
+//! 
 //! ```
 use tokio::runtime::Runtime;
 use tokio::net::{TcpListener, TcpStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,28 +208,34 @@ impl EventHub {
 /// On success, returns an [`EventHub`] for receiving messages and
 /// connection/disconnection notifications.
 pub fn launch(port: u16) -> Result<EventHub, Error> {
-    let (tx, rx) = flume::unbounded();
+    let address = format!("0.0.0.0:{}", port);
+    let listener = std::net::TcpListener::bind(&address).map_err(|_| Error::FailedToStart)?;
+    return launch_from_std_listener(listener);
+}
 
+/// Start listening for websocket connections with the specified tcp listener.
+/// On success, returns an [`EventHub`] for receiving messages and
+/// connection/disconnection notifications.
+pub fn launch_from_std_listener(listener: std::net::TcpListener) -> Result<EventHub, Error> {
+    let (tx, rx) = flume::unbounded();
     std::thread::Builder::new()
         .name("Websocket listener".to_string())
         .spawn(move || {
-            start_runtime(tx, port).unwrap();
+            start_runtime(tx, listener).unwrap();
         }).map_err(|_| Error::FailedToStart)?;
 
     Ok(EventHub::new(rx))
 }
 
-fn start_runtime(event_tx: flume::Sender<Event>, port: u16) -> Result<(), Error> {
+fn start_runtime(event_tx: flume::Sender<Event>, listener: std::net::TcpListener) -> Result<(), Error> {
+    listener.set_nonblocking(true).map_err(|_| Error::FailedToStart)?;
     Runtime::new()
         .map_err(|_| Error::FailedToStart)?
         .block_on(async {
-            let address = format!("0.0.0.0:{}", port);
-            let listener = TcpListener::bind(&address).await
-                .map_err(|_| Error::FailedToStart)?;
-
+            let tokio_listener = TcpListener::from_std(listener).unwrap();
             let mut current_id: u64 = 0;
             loop {
-                match listener.accept().await {
+                match tokio_listener.accept().await {
                     Ok((stream, _)) => {
                         tokio::spawn(handle_connection(stream, event_tx.clone(), current_id));
                         current_id = current_id.wrapping_add(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! fn main() {
 //!     // Example of using a pre-bound listener instead of providing a port.
 //!     let listener = TcpListener::bind(format!("0.0.0.0:8080")).unwrap();
-//!     let websocket_event_hub = simple_websockets::launch_from_listener(listener).expect("failed to listen on port 8080");
+//!     let event_hub = simple_websockets::launch_from_listener(listener).expect("failed to listen on port 8080");
 //! 
 //!     ...
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,13 +210,13 @@ impl EventHub {
 pub fn launch(port: u16) -> Result<EventHub, Error> {
     let address = format!("0.0.0.0:{}", port);
     let listener = std::net::TcpListener::bind(&address).map_err(|_| Error::FailedToStart)?;
-    return launch_from_std_listener(listener);
+    return launch_from_listener(listener);
 }
 
 /// Start listening for websocket connections with the specified tcp listener.
 /// On success, returns an [`EventHub`] for receiving messages and
 /// connection/disconnection notifications.
-pub fn launch_from_std_listener(listener: std::net::TcpListener) -> Result<EventHub, Error> {
+pub fn launch_from_listener(listener: std::net::TcpListener) -> Result<EventHub, Error> {
     let (tx, rx) = flume::unbounded();
     std::thread::Builder::new()
         .name("Websocket listener".to_string())

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::net::{TcpListener, SocketAddr};
+    use std::net::{TcpListener};
 
     use simple_websockets;
     use url::Url;
@@ -55,12 +55,14 @@ mod tests {
 
         // Connect some clients and send from the middle one to ensure no bug exists that always returns first or last client id for a received message
         let (_client_0, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_1, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_2, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        std::thread::sleep(std::time::Duration::from_millis(500));
         assert_connect_event(websocket_event_hub.poll_event(), 0);
+
+        let (mut client_1, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         assert_connect_event(websocket_event_hub.poll_event(), 1);
+
+        let (mut client_2, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         assert_connect_event(websocket_event_hub.poll_event(), 2);
+
         assert!(websocket_event_hub.is_empty());
         
         client_1.write_message(tungstenite::Message::Text(String::from("Hello from client 1!"))).expect("Error sending text message");
@@ -68,8 +70,9 @@ mod tests {
         assert!(websocket_event_hub.is_empty());
 
         client_1.write_message(tungstenite::Message::Text(String::from("Hello from client 1 again!"))).expect("Error sending text message");
-        client_2.write_message(tungstenite::Message::Text(String::from("Hello from client 2!"))).expect("Error sending text message");
         assert_text_message_event(websocket_event_hub.poll_event(), 1, "Hello from client 1 again!");
+
+        client_2.write_message(tungstenite::Message::Text(String::from("Hello from client 2!"))).expect("Error sending text message");
         assert_text_message_event(websocket_event_hub.poll_event(), 2, "Hello from client 2!");
         assert!(websocket_event_hub.is_empty());
     }
@@ -84,12 +87,15 @@ mod tests {
 
         // Connect some clients and send from the middle one to ensure no bug exists that always returns first or last client id for a received message
         let (_client_0, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_1, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_2, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        std::thread::sleep(std::time::Duration::from_millis(500));
         assert_connect_event(websocket_event_hub.poll_event(), 0);
+
+        let (mut client_1, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         assert_connect_event(websocket_event_hub.poll_event(), 1);
+
+        let (mut client_2, _) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         assert_connect_event(websocket_event_hub.poll_event(), 2);
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
         assert!(websocket_event_hub.is_empty());
         
         client_1.write_message(tungstenite::Message::Binary(vec![1, 2, 3])).expect("Error sending text message");
@@ -97,8 +103,9 @@ mod tests {
         assert!(websocket_event_hub.is_empty());
 
         client_1.write_message(tungstenite::Message::Binary(vec![])).expect("Error sending text message");
-        client_2.write_message(tungstenite::Message::Binary(vec![4, 5, 6])).expect("Error sending text message");
         assert_binary_message_event(websocket_event_hub.poll_event(), 1, vec![]);
+
+        client_2.write_message(tungstenite::Message::Binary(vec![4, 5, 6])).expect("Error sending text message");
         assert_binary_message_event(websocket_event_hub.poll_event(), 2, vec![4,5,6]);
         assert!(websocket_event_hub.is_empty());
     }
@@ -114,12 +121,14 @@ mod tests {
 
         // Connect some clients and send from the middle one to ensure no bug exists that always returns first or last client id for a received message
         let (_c0, _r0) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_1, _r1) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_2, _r2) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        std::thread::sleep(std::time::Duration::from_millis(500));
         assert_connect_event(websocket_event_hub.poll_event(), 0);
+
+        let (mut client_1, _r1) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         let (_, responder_1) = assert_connect_event(websocket_event_hub.poll_event(), 1);
+
+        let (mut client_2, _r2) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         let (_, responder_2) = assert_connect_event(websocket_event_hub.poll_event(), 2);
+
         assert!(websocket_event_hub.is_empty());
         
         responder_1.send(simple_websockets::Message::Text("Hello client 1!".to_string()));
@@ -146,12 +155,14 @@ mod tests {
 
         // Connect some clients and send from the middle one to ensure no bug exists that always returns first or last client id for a received message
         let (_c0, _r0) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_1, _r1) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut client_2, _r2) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        std::thread::sleep(std::time::Duration::from_millis(500));
         assert_connect_event(websocket_event_hub.poll_event(), 0);
+
+        let (mut client_1, _r1) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         let (_, responder_1) = assert_connect_event(websocket_event_hub.poll_event(), 1);
+
+        let (mut client_2, _r2) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         let (_, responder_2) = assert_connect_event(websocket_event_hub.poll_event(), 2);
+        
         assert!(websocket_event_hub.is_empty());
         
         responder_1.send(simple_websockets::Message::Binary(vec![1,2,3]));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,15 +1,15 @@
 
 #[cfg(test)]
 mod tests {
+    use std::net::{TcpListener, SocketAddr};
+
     use simple_websockets;
     use url::Url;
 
     #[test]
     fn connect_disconnect_test() {
         // Start a server
-        const UNIQUE_TEST_PORT: u16 = 9000; // Future fix will eliminate this need
-        let server_endpoint = Url::parse(format!("ws://127.0.0.1:{UNIQUE_TEST_PORT}").as_str()).unwrap();
-        let websocket_event_hub = simple_websockets::launch(UNIQUE_TEST_PORT).expect(format!("failed to listen on websocket port {UNIQUE_TEST_PORT}").as_str());
+        let (websocket_event_hub, server_endpoint) = start_websocket_and_get_server_endpoint();
         std::thread::sleep(std::time::Duration::from_millis(500));
 
         assert!(websocket_event_hub.is_empty());
@@ -48,9 +48,7 @@ mod tests {
     #[test]
     fn receive_text_message_test() {
         // Start a server
-        const UNIQUE_TEST_PORT: u16 = 9001; // Future fix will eliminate this need
-        let server_endpoint = Url::parse(format!("ws://127.0.0.1:{UNIQUE_TEST_PORT}").as_str()).unwrap();
-        let websocket_event_hub = simple_websockets::launch(UNIQUE_TEST_PORT).expect(format!("failed to listen on websocket port {UNIQUE_TEST_PORT}").as_str());
+        let (websocket_event_hub, server_endpoint) = start_websocket_and_get_server_endpoint();
         std::thread::sleep(std::time::Duration::from_millis(500));
 
         assert!(websocket_event_hub.is_empty());
@@ -79,9 +77,7 @@ mod tests {
     #[test]
     fn receive_binary_message_test() {
         // Start a server
-        const UNIQUE_TEST_PORT: u16 = 9002; // Future fix will eliminate this need
-        let server_endpoint = Url::parse(format!("ws://127.0.0.1:{UNIQUE_TEST_PORT}").as_str()).unwrap();
-        let websocket_event_hub = simple_websockets::launch(UNIQUE_TEST_PORT).expect(format!("failed to listen on websocket port {UNIQUE_TEST_PORT}").as_str());
+        let (websocket_event_hub, server_endpoint) = start_websocket_and_get_server_endpoint();
         std::thread::sleep(std::time::Duration::from_millis(500));
 
         assert!(websocket_event_hub.is_empty());
@@ -111,9 +107,7 @@ mod tests {
     #[test]
     fn send_text_message_test() {
         // Start a server
-        const UNIQUE_TEST_PORT: u16 = 9003; // Future fix will eliminate this need
-        let server_endpoint = Url::parse(format!("ws://127.0.0.1:{UNIQUE_TEST_PORT}").as_str()).unwrap();
-        let websocket_event_hub = simple_websockets::launch(UNIQUE_TEST_PORT).expect(format!("failed to listen on websocket port {UNIQUE_TEST_PORT}").as_str());
+        let (websocket_event_hub, server_endpoint) = start_websocket_and_get_server_endpoint();
         std::thread::sleep(std::time::Duration::from_millis(500));
 
         assert!(websocket_event_hub.is_empty());
@@ -145,9 +139,7 @@ mod tests {
     #[test]
     fn send_binary_message_test() {
         // Start a server
-        const UNIQUE_TEST_PORT: u16 = 9004; // Future fix will eliminate this need
-        let server_endpoint = Url::parse(format!("ws://127.0.0.1:{UNIQUE_TEST_PORT}").as_str()).unwrap();
-        let websocket_event_hub = simple_websockets::launch(UNIQUE_TEST_PORT).expect(format!("failed to listen on websocket port {UNIQUE_TEST_PORT}").as_str());
+        let (websocket_event_hub, server_endpoint) = start_websocket_and_get_server_endpoint();
         std::thread::sleep(std::time::Duration::from_millis(500));
         
         assert!(websocket_event_hub.is_empty());
@@ -186,6 +178,14 @@ mod tests {
         }
     }
 
+    fn start_websocket_and_get_server_endpoint() -> (simple_websockets::EventHub, Url){
+        let listener = TcpListener::bind(format!("0.0.0.0:0")).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        
+        let websocket_event_hub = simple_websockets::launch_from_std_listener(listener).expect(format!("failed to listen on websocket port unspecified port").as_str());
+        let server_endpoint = Url::parse(format!("ws://127.0.0.1:{port}").as_str()).unwrap();
+        return (websocket_event_hub, server_endpoint);
+    }
 
     fn assert_connect_event(e: simple_websockets::Event, expected_client_id: u64) -> (u64, simple_websockets::Responder)
     {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,6 @@
-
 #[cfg(test)]
 mod tests {
-    use std::net::{TcpListener};
+    use std::net::TcpListener;
 
     use simple_websockets;
     use url::Url;
@@ -13,31 +12,38 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(500));
 
         assert!(websocket_event_hub.is_empty());
-        
+
         // Connect and disconnect some clients and assert on server events
-        let (mut client_0, _response_0) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        std::thread::sleep(std::time::Duration::from_millis(500)); // Ensure event is actually triggered. The longer the wait, the slower test. The short the wait the higher risk of getting an unstable test. Optimal solution would be for 
+        let (mut client_0, _response_0) =
+            tungstenite::connect(&server_endpoint).expect("Can't connect");
+        std::thread::sleep(std::time::Duration::from_millis(500)); // Ensure event is actually triggered. The longer the wait, the slower test. The short the wait the higher risk of getting an unstable test. Optimal solution would be for
         assert_connect_event(websocket_event_hub.poll_event(), 0);
         assert!(websocket_event_hub.is_empty());
 
-        let (mut client_1, _response_1) = tungstenite::connect(&server_endpoint).expect("Can't connect");
-        let (mut _client_2, _response_2) = tungstenite::connect(&server_endpoint).expect("Can't connect");
+        let (mut client_1, _response_1) =
+            tungstenite::connect(&server_endpoint).expect("Can't connect");
+        let (mut _client_2, _response_2) =
+            tungstenite::connect(&server_endpoint).expect("Can't connect");
 
         std::thread::sleep(std::time::Duration::from_millis(500));
         assert!(!websocket_event_hub.is_empty());
         assert_connect_event(websocket_event_hub.poll_event(), 1);
         assert!(!websocket_event_hub.is_empty());
-        assert_connect_event(websocket_event_hub.poll_event(), 2); 
+        assert_connect_event(websocket_event_hub.poll_event(), 2);
         assert!(websocket_event_hub.is_empty());
 
-        client_1.close(None).expect("Expected no panic from close call");
+        client_1
+            .close(None)
+            .expect("Expected no panic from close call");
         std::thread::sleep(std::time::Duration::from_millis(500));
         assert!(!websocket_event_hub.is_empty());
 
         assert_disconnect_event(websocket_event_hub.poll_event(), 1);
         assert!(websocket_event_hub.is_empty());
 
-        client_0.close(None).expect("Expected no panic from close call");
+        client_0
+            .close(None)
+            .expect("Expected no panic from close call");
         std::thread::sleep(std::time::Duration::from_millis(500));
         assert!(!websocket_event_hub.is_empty());
 
@@ -64,15 +70,31 @@ mod tests {
         assert_connect_event(websocket_event_hub.poll_event(), 2);
 
         assert!(websocket_event_hub.is_empty());
-        
-        client_1.write_message(tungstenite::Message::Text(String::from("Hello from client 1!"))).expect("Error sending text message");
+
+        client_1
+            .write_message(tungstenite::Message::Text(String::from(
+                "Hello from client 1!",
+            )))
+            .expect("Error sending text message");
         assert_text_message_event(websocket_event_hub.poll_event(), 1, "Hello from client 1!");
         assert!(websocket_event_hub.is_empty());
 
-        client_1.write_message(tungstenite::Message::Text(String::from("Hello from client 1 again!"))).expect("Error sending text message");
-        assert_text_message_event(websocket_event_hub.poll_event(), 1, "Hello from client 1 again!");
+        client_1
+            .write_message(tungstenite::Message::Text(String::from(
+                "Hello from client 1 again!",
+            )))
+            .expect("Error sending text message");
+        assert_text_message_event(
+            websocket_event_hub.poll_event(),
+            1,
+            "Hello from client 1 again!",
+        );
 
-        client_2.write_message(tungstenite::Message::Text(String::from("Hello from client 2!"))).expect("Error sending text message");
+        client_2
+            .write_message(tungstenite::Message::Text(String::from(
+                "Hello from client 2!",
+            )))
+            .expect("Error sending text message");
         assert_text_message_event(websocket_event_hub.poll_event(), 2, "Hello from client 2!");
         assert!(websocket_event_hub.is_empty());
     }
@@ -97,20 +119,25 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_millis(500));
         assert!(websocket_event_hub.is_empty());
-        
-        client_1.write_message(tungstenite::Message::Binary(vec![1, 2, 3])).expect("Error sending text message");
+
+        client_1
+            .write_message(tungstenite::Message::Binary(vec![1, 2, 3]))
+            .expect("Error sending text message");
         assert_binary_message_event(websocket_event_hub.poll_event(), 1, vec![1, 2, 3]);
         assert!(websocket_event_hub.is_empty());
 
-        client_1.write_message(tungstenite::Message::Binary(vec![])).expect("Error sending text message");
+        client_1
+            .write_message(tungstenite::Message::Binary(vec![]))
+            .expect("Error sending text message");
         assert_binary_message_event(websocket_event_hub.poll_event(), 1, vec![]);
 
-        client_2.write_message(tungstenite::Message::Binary(vec![4, 5, 6])).expect("Error sending text message");
-        assert_binary_message_event(websocket_event_hub.poll_event(), 2, vec![4,5,6]);
+        client_2
+            .write_message(tungstenite::Message::Binary(vec![4, 5, 6]))
+            .expect("Error sending text message");
+        assert_binary_message_event(websocket_event_hub.poll_event(), 2, vec![4, 5, 6]);
         assert!(websocket_event_hub.is_empty());
     }
 
-    
     #[test]
     fn send_text_message_test() {
         // Start a server
@@ -130,18 +157,26 @@ mod tests {
         let (_, responder_2) = assert_connect_event(websocket_event_hub.poll_event(), 2);
 
         assert!(websocket_event_hub.is_empty());
-        
-        responder_1.send(simple_websockets::Message::Text("Hello client 1!".to_string()));
-        responder_2.send(simple_websockets::Message::Text("Hello client 2!".to_string()));
-        
-        match  client_1.read_message().unwrap(){
-            tungstenite::Message::Text(text) => {assert_eq!("Hello client 1!", text);}
-            _ => panic!("Unexpected type!")
+
+        responder_1.send(simple_websockets::Message::Text(
+            "Hello client 1!".to_string(),
+        ));
+        responder_2.send(simple_websockets::Message::Text(
+            "Hello client 2!".to_string(),
+        ));
+
+        match client_1.read_message().unwrap() {
+            tungstenite::Message::Text(text) => {
+                assert_eq!("Hello client 1!", text);
+            }
+            _ => panic!("Unexpected type!"),
         }
-        
-        match  client_2.read_message().unwrap(){
-            tungstenite::Message::Text(text) => {assert_eq!("Hello client 2!", text);}
-            _ => panic!("Unexpected type!")
+
+        match client_2.read_message().unwrap() {
+            tungstenite::Message::Text(text) => {
+                assert_eq!("Hello client 2!", text);
+            }
+            _ => panic!("Unexpected type!"),
         }
     }
 
@@ -150,7 +185,7 @@ mod tests {
         // Start a server
         let (websocket_event_hub, server_endpoint) = start_websocket_and_get_server_endpoint();
         std::thread::sleep(std::time::Duration::from_millis(500));
-        
+
         assert!(websocket_event_hub.is_empty());
 
         // Connect some clients and send from the middle one to ensure no bug exists that always returns first or last client id for a received message
@@ -162,30 +197,30 @@ mod tests {
 
         let (mut client_2, _r2) = tungstenite::connect(&server_endpoint).expect("Can't connect");
         let (_, responder_2) = assert_connect_event(websocket_event_hub.poll_event(), 2);
-        
+
         assert!(websocket_event_hub.is_empty());
-        
-        responder_1.send(simple_websockets::Message::Binary(vec![1,2,3]));
-        responder_2.send(simple_websockets::Message::Binary(vec![4,5,6]));
-        
-        match  client_1.read_message().unwrap(){
+
+        responder_1.send(simple_websockets::Message::Binary(vec![1, 2, 3]));
+        responder_2.send(simple_websockets::Message::Binary(vec![4, 5, 6]));
+
+        match client_1.read_message().unwrap() {
             tungstenite::Message::Binary(bytes) => {
                 assert_eq!(3, bytes.len());
                 assert_eq!(1, bytes[0]);
                 assert_eq!(2, bytes[1]);
                 assert_eq!(3, bytes[2]);
             }
-            _ => panic!("Unexpected type!")
+            _ => panic!("Unexpected type!"),
         }
-        
-        match  client_2.read_message().unwrap(){
+
+        match client_2.read_message().unwrap() {
             tungstenite::Message::Binary(bytes) => {
                 assert_eq!(3, bytes.len());
                 assert_eq!(4, bytes[0]);
                 assert_eq!(5, bytes[1]);
                 assert_eq!(6, bytes[2]);
             }
-            _ => panic!("Unexpected type!")
+            _ => panic!("Unexpected type!"),
         }
     }
 
@@ -199,62 +234,92 @@ mod tests {
         simple_websockets::launch(taken_port).expect_err("Expected error binding to same port");
     }
 
-    fn start_websocket_and_get_server_endpoint() -> (simple_websockets::EventHub, Url){
+    fn start_websocket_and_get_server_endpoint() -> (simple_websockets::EventHub, Url) {
         let listener = TcpListener::bind(format!("0.0.0.0:0")).unwrap();
         let port = listener.local_addr().unwrap().port();
-        
-        let websocket_event_hub = simple_websockets::launch_from_listener(listener).expect(format!("failed to listen on websocket port unspecified port").as_str());
+
+        let websocket_event_hub = simple_websockets::launch_from_listener(listener)
+            .expect(format!("failed to listen on websocket port unspecified port").as_str());
         let server_endpoint = Url::parse(format!("ws://127.0.0.1:{port}").as_str()).unwrap();
         return (websocket_event_hub, server_endpoint);
     }
 
-    fn assert_connect_event(e: simple_websockets::Event, expected_client_id: u64) -> (u64, simple_websockets::Responder)
-    {
-        match e{
+    fn assert_connect_event(
+        e: simple_websockets::Event,
+        expected_client_id: u64,
+    ) -> (u64, simple_websockets::Responder) {
+        match e {
             simple_websockets::Event::Connect(client_id, responder) => {
                 assert_eq!(expected_client_id, client_id);
                 return (client_id, responder);
-            },
-            simple_websockets::Event::Disconnect(_client_id) => panic!("Disconnect event received but expected connect event"),
-            simple_websockets::Event::Message(_client_id, _message) => panic!("Message event received but expected connect event")
+            }
+            simple_websockets::Event::Disconnect(_client_id) => {
+                panic!("Disconnect event received but expected connect event")
+            }
+            simple_websockets::Event::Message(_client_id, _message) => {
+                panic!("Message event received but expected connect event")
+            }
         }
     }
 
-    fn assert_disconnect_event(e: simple_websockets::Event, expected_client_id: u64)
-    {
-        match e{
-            simple_websockets::Event::Connect(_client_id, _response) => panic!("Connect event received but expected disconnect event"),
-            simple_websockets::Event::Disconnect(client_id) => { assert_eq!(expected_client_id, client_id)},
-            simple_websockets::Event::Message(_client_id, _message) => panic!("Message event received but expected disconnect event")
+    fn assert_disconnect_event(e: simple_websockets::Event, expected_client_id: u64) {
+        match e {
+            simple_websockets::Event::Connect(_client_id, _response) => {
+                panic!("Connect event received but expected disconnect event")
+            }
+            simple_websockets::Event::Disconnect(client_id) => {
+                assert_eq!(expected_client_id, client_id)
+            }
+            simple_websockets::Event::Message(_client_id, _message) => {
+                panic!("Message event received but expected disconnect event")
+            }
         }
     }
 
-    fn assert_text_message_event(e: simple_websockets::Event, expected_client_id: u64, expected_text_content: &str)
-    {
-        match e{
-            simple_websockets::Event::Connect(_client_id, _response) => panic!("Connect event received but expected text message event"),
-            simple_websockets::Event::Disconnect(_client_id) => panic!("Disconnect event received but expected text message event"),
+    fn assert_text_message_event(
+        e: simple_websockets::Event,
+        expected_client_id: u64,
+        expected_text_content: &str,
+    ) {
+        match e {
+            simple_websockets::Event::Connect(_client_id, _response) => {
+                panic!("Connect event received but expected text message event")
+            }
+            simple_websockets::Event::Disconnect(_client_id) => {
+                panic!("Disconnect event received but expected text message event")
+            }
             simple_websockets::Event::Message(client_id, message) => {
                 assert_eq!(expected_client_id, client_id);
-                match message{
+                match message {
                     simple_websockets::Message::Text(msg) => {
                         assert_eq!(expected_text_content, msg);
-                    },
-                    simple_websockets::Message::Binary(_) => panic!("Binary message received but expected text message")
+                    }
+                    simple_websockets::Message::Binary(_) => {
+                        panic!("Binary message received but expected text message")
+                    }
                 }
             }
         }
     }
 
-    fn assert_binary_message_event(e: simple_websockets::Event, expected_client_id: u64, expected_binary_content: Vec<u8>)
-    {
-        match e{
-            simple_websockets::Event::Connect(_client_id, _response) => panic!("Connect event received but expected binary message event"),
-            simple_websockets::Event::Disconnect(_client_id) => panic!("Disconnect event received but expected binary message event"),
+    fn assert_binary_message_event(
+        e: simple_websockets::Event,
+        expected_client_id: u64,
+        expected_binary_content: Vec<u8>,
+    ) {
+        match e {
+            simple_websockets::Event::Connect(_client_id, _response) => {
+                panic!("Connect event received but expected binary message event")
+            }
+            simple_websockets::Event::Disconnect(_client_id) => {
+                panic!("Disconnect event received but expected binary message event")
+            }
             simple_websockets::Event::Message(client_id, message) => {
                 assert_eq!(expected_client_id, client_id);
-                match message{
-                    simple_websockets::Message::Text(_) => panic!("Text message received but expected text message"),
+                match message {
+                    simple_websockets::Message::Text(_) => {
+                        panic!("Text message received but expected text message")
+                    }
                     simple_websockets::Message::Binary(bytes) => {
                         assert_eq!(expected_binary_content.len(), bytes.len());
                         let mut i = 0;
@@ -262,7 +327,7 @@ mod tests {
                             assert_eq!(expected_binary_content[i], bytes[i]);
                             i += 1;
                         }
-                    },
+                    }
                 }
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -203,7 +203,7 @@ mod tests {
         let listener = TcpListener::bind(format!("0.0.0.0:0")).unwrap();
         let port = listener.local_addr().unwrap().port();
         
-        let websocket_event_hub = simple_websockets::launch_from_std_listener(listener).expect(format!("failed to listen on websocket port unspecified port").as_str());
+        let websocket_event_hub = simple_websockets::launch_from_listener(listener).expect(format!("failed to listen on websocket port unspecified port").as_str());
         let server_endpoint = Url::parse(format!("ws://127.0.0.1:{port}").as_str()).unwrap();
         return (websocket_event_hub, server_endpoint);
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -178,6 +178,16 @@ mod tests {
         }
     }
 
+    #[test]
+    fn launch_bind_failed_expect_error_received_test() {
+        // Occupy a random port
+        let listener = TcpListener::bind(format!("0.0.0.0:0")).unwrap();
+        let taken_port = listener.local_addr().unwrap().port();
+
+        // Call launch with the port that we now know is taken - expect an error
+        simple_websockets::launch(taken_port).expect_err("Expected error binding to same port");
+    }
+
     fn start_websocket_and_get_server_endpoint() -> (simple_websockets::EventHub, Url){
         let listener = TcpListener::bind(format!("0.0.0.0:0")).unwrap();
         let port = listener.local_addr().unwrap().port();


### PR DESCRIPTION
Purpose is for tests to specify a listener that did not have a specific port, but got one assigned from the OS automatically.
This makes the tests easier to maintain and less risk of failing to bind.