### PR TITLE
derive Clone for Message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub enum Error {
 }
 
 /// An outgoing/incoming message to/from a websocket.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Message {
     /// A text message
     Text(String),


### PR DESCRIPTION
Both of the variants of `Message` are trivially cloneable, so it would make sense for `Message` to be cloneable.